### PR TITLE
One tool moved to get rid of a section.

### DIFF
--- a/tools.yaml
+++ b/tools.yaml
@@ -4,6 +4,12 @@ install_resolver_dependencies: true
 install_tool_dependencies: false
 
 tools:
+
+- name: dwt_var_perfeature
+  owner: devteam
+  tool_panel_section_id: statistics
+  tool_shed_url: https://toolshed.g2.bx.psu.edu
+
 - name: bedtools
   install_repository_dependencies: true
   install_resolver_dependencies: true
@@ -3167,13 +3173,6 @@ tools:
   name: genome_diversity
   owner: miller-lab
   tool_panel_section_label: Genome Diversity
-  tool_shed_url: toolshed.g2.bx.psu.edu
-- install_repository_dependencies: true
-  install_resolver_dependencies: true
-  install_tool_dependencies: false
-  name: dwt_var_perfeature
-  owner: devteam
-  tool_panel_section_label: Wavelet Analysis
   tool_shed_url: toolshed.g2.bx.psu.edu
 - install_repository_dependencies: true
   install_resolver_dependencies: true


### PR DESCRIPTION
Hi Björn. This should serve as an example of how I would adapt the format in the tools.yaml
Note that I don't use the 

> tool_panel_section_label

 but the 
> tool_panel_section_id

instead. I think that's cleaner. And also I leave out the information about the dependencies if they are as per default. If you think this is fine and accept the pull request, then I will do the other changes accordingly.